### PR TITLE
Python 2.7 backward compat.

### DIFF
--- a/jwst_footprints/__init__.py
+++ b/jwst_footprints/__init__.py
@@ -1,4 +1,6 @@
 from os.path import abspath, dirname, expanduser, join
+
+
 PKG_DIR = dirname(abspath(__file__))
 PKG_DATA_DIR = join(PKG_DIR, 'data')
 CONFIG_DIR = join(expanduser('~'), '.jwst_footprints')

--- a/jwst_footprints/astro_funcx.py
+++ b/jwst_footprints/astro_funcx.py
@@ -2,7 +2,7 @@
 # Version 1. August 2, 2010
 # Version 2. August 3, 2010
 #   Got rid of degrees trig functions
-
+from __future__ import absolute_import, division, print_function
 from math import atan2, acos, cos, sin, pi
 
 D2R = pi / 180.

--- a/jwst_footprints/ephemeris_old2x.py
+++ b/jwst_footprints/ephemeris_old2x.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python
 # Module ephemeris.py
+from __future__ import absolute_import, division, print_function
 
 import sys
 import time
-from math import asin, atan2, cos, sin, pi
 
+from math import asin, atan2, cos, sin, pi
 from . import astro_funcx as astro_func
 from . import quaternionx
 from . import rotationsx

--- a/jwst_footprints/find_tgt_info.py
+++ b/jwst_footprints/find_tgt_info.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from __future__ import absolute_import, division, print_function
 
 import os
 import sys

--- a/jwst_footprints/footprints.py
+++ b/jwst_footprints/footprints.py
@@ -15,10 +15,13 @@ Based on work by Colin Cox and Wayne Kinzel
 
 """
 
+from __future__ import absolute_import, division, print_function
+
 import sys
 import os
-from math import *
 import numpy as np
+
+from math import *
 from astropy import wcs
 from astropy.io import fits
 from astropy.io import ascii

--- a/jwst_footprints/launch_footprints.py
+++ b/jwst_footprints/launch_footprints.py
@@ -1,15 +1,24 @@
 #!/usr/bin/env python
 # encoding: utf-8
+from __future__ import absolute_import, division, print_function
+
 import json
 import os
+
 from jwst_footprints import PKG_DATA_DIR, CONFIG_DIR, CONFIG_FILE
 from jwst_footprints.footprints import footprints
 from jwst_footprints.defaults import default_config
 from jwst_footprints.plot_timeline import plottimeline
 
-from tkinter import Tk, Button, Entry, Label, OptionMenu, StringVar, \
-                    Toplevel, TRUE, FALSE
-from tkinter.filedialog import askopenfilename
+try:
+    from Tkinter import (Tk, Button, Entry, Label, OptionMenu, StringVar, \
+                         Toplevel, TRUE, FALSE)
+    from tkFileDialog import askopenfilename
+except ImportError as e:
+    from tkinter.filedialog import askopenfilename
+    from tkinter import (Tk, Button, Entry, Label, OptionMenu, StringVar, \
+                         Toplevel, TRUE, FALSE)
+
 from PIL import ImageTk
 
 

--- a/jwst_footprints/math_extensionsx.py
+++ b/jwst_footprints/math_extensionsx.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from __future__ import absolute_import, division, print_function
 # math_extensions module
 
 """This module provides simple extensions to the Python mathematical library."""

--- a/jwst_footprints/plot_timeline.py
+++ b/jwst_footprints/plot_timeline.py
@@ -1,15 +1,15 @@
 #! /usr/bin/env python
+from __future__ import absolute_import, division, print_function
 
-
-# load modules
+import datetime
 import matplotlib
 matplotlib.use("TkAgg")
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
+import numpy as np
+
 from astropy.io import ascii
 from astropy.time import Time
-import numpy as np
-import datetime
 from .find_tgt_info import *
 
 

--- a/jwst_footprints/quaternionx.py
+++ b/jwst_footprints/quaternionx.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from __future__ import absolute_import, division, print_function
 # quaternion module
 
 """Version 4 September 9, 2010 WMK
@@ -23,7 +24,7 @@ Modified cnvrt method to return a CelestialVector."""
 #  Version 1.0 August 3, 2010
 #  Got rid of degrees trig functions.
 
-from math import *
+#from math import *
 import math
 from .math_extensionsx import *
 from . import rotationsx as rot

--- a/jwst_footprints/rotationsx.py
+++ b/jwst_footprints/rotationsx.py
@@ -1,12 +1,10 @@
 #! /usr/bin/env python
 """Module for general rotations library."""
+from __future__ import absolute_import, division, print_function
 
-#import random
 import math
-from math import *
+#from . import quaternionx
 from . import math_extensionsx as math2
-from . import quaternionx as quat
-
 
 class GalacticPole (object):
     """Represents coordinates of galactic pole."""
@@ -19,9 +17,9 @@ class GalacticPole (object):
         ascending_node = ascending node of pole, in degrees."""
 
         # Arguments specified in degrees, but values represented in radians.
-        self.latitude = radians(latitude)
-        self.longitude = radians(longitude)
-        self.anode = radians(ascending_node)
+        self.latitude = math.radians(latitude)
+        self.longitude = math.radians(longitude)
+        self.anode = math.radians(ascending_node)
 
     def __str__(self):
         """Returns string representation of the galactic pole."""
@@ -475,7 +473,7 @@ Any subset of the Cartesian coordinates may be specifed."""
         This is an alternative formulation for rotate_about_eigenaxis.
         Interface is the same as rotate_about_eigenaxis."""
 
-        q = quat.Quaternion(eigenaxis, 0.0)
+        q = Quaternion(eigenaxis, 0.0)
 
         # Need to negate here because set_values performs a negative rotation
         # quaternion now represents the rotation


### PR DESCRIPTION
One outstanding bug here:
In `rotationsx` under python2.7, we cannot resolve `from . import quaternionx`. This may have something to do with `from blah import *` breaking resolution. I can't tell.
